### PR TITLE
Add backend stubs and data loader integration

### DIFF
--- a/client_stub.js
+++ b/client_stub.js
@@ -1,0 +1,61 @@
+/*
+ * Basic JavaScript client used as a reference for invoking the four backends.
+ * Each function illustrates how a real client could send requests to the
+ * respective service. For simplicidade, as implementações reais deverão lidar
+ * com tratamento de erros, autenticação e detalhes específicos de cada
+ * protocolo.
+ */
+
+// URLs padrão dos serviços
+const REST_URL = 'http://localhost:8000';
+const GRAPHQL_URL = 'http://localhost:8001/graphql';
+const SOAP_URL = 'http://localhost:8002/soap';
+const GRPC_URL = 'http://localhost:50051'; // gRPC usa porta separada
+
+// -------------------- REST --------------------
+export async function listarUsuariosREST() {
+  // Exemplo simples de chamada REST utilizando fetch
+  const resp = await fetch(`${REST_URL}/usuarios`);
+  return resp.json();
+}
+
+// -------------------- GraphQL -----------------
+export async function listarUsuariosGraphQL() {
+  const query = `{ usuarios { id nome idade } }`;
+  const resp = await fetch(GRAPHQL_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query })
+  });
+  const data = await resp.json();
+  return data.data.usuarios;
+}
+
+// -------------------- SOAP --------------------
+export async function listarUsuariosSOAP() {
+  /*
+   * Para consumir SOAP via navegador seria necessário utilizar uma biblioteca
+   * específica ou enviar manualmente o envelope XML. Abaixo deixamos um
+   * esqueleto de requisição que poderá ser completado com a biblioteca de sua
+   * preferência (ex. soap-js). O endpoint do serviço deve expor o WSDL em
+   * `${SOAP_URL}?wsdl`.
+   */
+  const envelope = `<?xml version="1.0"?>\n<soap:Envelope>...</soap:Envelope>`;
+  const resp = await fetch(SOAP_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'text/xml' },
+    body: envelope
+  });
+  const text = await resp.text();
+  return text; // TODO: parsear XML
+}
+
+// -------------------- gRPC --------------------
+export async function listarUsuariosGRPC() {
+  /*
+   * Browsers não se conectam diretamente a serviços gRPC; em um cliente Node.js
+   * utilize o pacote @grpc/grpc-js. Este stub indica onde conectar e como a
+   * chamada pode ser estruturada.
+   */
+  throw new Error('gRPC client não implementado. Use Node.js para testar.');
+}

--- a/graphql_service.py
+++ b/graphql_service.py
@@ -19,6 +19,9 @@ from fastapi.responses import HTMLResponse
 from typing import List, Optional
 from contextlib import asynccontextmanager
 
+# Loader de dados real utilizado por todos os backends
+from data_loader import get_data_loader
+
 # ========== TIPOS GRAPHQL ==========
 
 @strawberry.type
@@ -61,6 +64,8 @@ class Estatisticas:
 # ========== DATA LOADER (Simulação) ==========
 
 class GraphQLDataLoader:
+    """Loader de dados mock utilizado apenas para ambientes de demonstração."""
+
     def __init__(self):
         self.usuarios = [
             {"id": "user1", "nome": "Ana Silva", "idade": 28},
@@ -69,7 +74,6 @@ class GraphQLDataLoader:
             {"id": "user4", "nome": "Pedro Lima", "idade": 45},
             {"id": "user5", "nome": "Lucia Ferreira", "idade": 31}
         ]
-
         self.musicas = [
             {"id": "music1", "nome": "Amor Perfeito", "artista": "Ana Silva", "duracaoSegundos": 240},
             {"id": "music2", "nome": "Noite Estrelada", "artista": "João Santos", "duracaoSegundos": 210},
@@ -80,7 +84,6 @@ class GraphQLDataLoader:
             {"id": "music7", "nome": "Tempestade", "artista": "João Santos", "duracaoSegundos": 190},
             {"id": "music8", "nome": "Serenata", "artista": "Maria Costa", "duracaoSegundos": 175}
         ]
-
         self.playlists = [
             {"id": "playlist1", "nome": "Meus Favoritos", "idUsuario": "user1", "musicas": ["music1", "music2", "music5"]},
             {"id": "playlist2", "nome": "Relaxar", "idUsuario": "user1", "musicas": ["music3", "music6", "music8"]},
@@ -88,10 +91,16 @@ class GraphQLDataLoader:
             {"id": "playlist4", "nome": "Workout Mix", "idUsuario": "user3", "musicas": ["music2", "music4", "music7"]}
         ]
 
-        print(f"✅ GraphQL Data Loader inicializado")
+        print("✅ GraphQL Data Loader (mock) inicializado")
 
-# Instância global
-data_loader = GraphQLDataLoader()
+# Instância global: tenta usar dados reais e faz fallback para o mock
+try:
+    data_loader = get_data_loader()
+    print("✅ Dados reais carregados para GraphQL")
+except Exception as exc:
+    print(f"⚠️  Erro ao carregar dados reais: {exc}")
+    print("🔄 Utilizando GraphQLDataLoader mock")
+    data_loader = GraphQLDataLoader()
 
 # ========== RESOLVERS ==========
 

--- a/grpc_service.py
+++ b/grpc_service.py
@@ -1,0 +1,56 @@
+"""gRPC Backend Stub
+===================
+
+Estrutura inicial para o servidor gRPC em Python. As definições de mensagens e
+serviços devem ser descritas em ``streaming.proto`` e compiladas com
+``grpcio-tools`` para gerar ``streaming_pb2.py`` e ``streaming_pb2_grpc.py``.
+Este arquivo demonstra onde integrar o ``StreamingDataLoader`` com o código
+proveniente do ``protoc``.
+"""
+
+from concurrent import futures
+import grpc
+
+from data_loader import get_data_loader
+
+# import streaming_pb2
+# import streaming_pb2_grpc
+
+
+data_loader = get_data_loader()
+
+
+# class StreamingService(streaming_pb2_grpc.StreamingServiceServicer):
+#     """Implementação das operações definidas em streaming.proto."""
+#
+#     def __init__(self):
+#         self.loader = data_loader
+#
+#     def ListarTodosUsuarios(self, request, context):
+#         """Exemplo de método gRPC retornando todos os usuários."""
+#         usuarios = self.loader.listar_todos_usuarios()
+#         # TODO: montar e retornar ``streaming_pb2.UsuariosResponse``
+#         raise NotImplementedError
+#
+#     # Demais métodos (ListarPlaylistsUsuario, ListarMusicasPlaylist, etc.)
+#     # devem seguir a mesma lógica utilizando o ``data_loader``.
+
+
+def servir(porta: int = 50051) -> None:
+    """Inicializa o servidor gRPC.
+
+    Esta função cria ``grpc.server`` e registra ``StreamingService``. Os detalhes
+    da resposta são deixados como TODO para implementação futura.
+    """
+    # server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+    # streaming_pb2_grpc.add_StreamingServiceServicer_to_server(
+    #     StreamingService(), server
+    # )
+    # server.add_insecure_port(f"[::]:{porta}")
+    # server.start()
+    # server.wait_for_termination()
+    raise NotImplementedError("Implementar servidor gRPC utilizando grpcio")
+
+
+if __name__ == "__main__":
+    servir()

--- a/rest_service.py
+++ b/rest_service.py
@@ -19,7 +19,18 @@ import json
 import os
 from contextlib import asynccontextmanager
 
-# Simulação do data_loader (versão simplificada para ambiente web)
+# Importa o carregador real de dados gerados em ``data/``
+from data_loader import get_data_loader
+
+# ---------------------------------------------------------------------------
+# Observação sobre o antigo ``SimpleDataLoader``
+# ---------------------------------------------------------------------------
+# A implementação original deste serviço usava dados "mock" em memória para
+# facilitar a execução em ambientes web. Para o trabalho final, os dados devem
+# ser carregados a partir dos arquivos JSON gerados por ``modelagem_dados.py``.
+# O ``StreamingDataLoader`` providencia consultas otimizadas e é compartilhado
+# entre todos os backends. A classe a seguir permanece apenas como referência de
+# como os exemplos eram estruturados.
 class SimpleDataLoader:
     def __init__(self):
         self.usuarios = []
@@ -28,8 +39,7 @@ class SimpleDataLoader:
         self._carregar_dados_mock()
 
     def _carregar_dados_mock(self):
-        """Carrega dados mock para demonstração (substitui arquivos JSON)"""
-        # Dados de exemplo para demonstração
+        """Carrega dados mock para demonstração (substitui arquivos JSON)."""
         self.usuarios = [
             {"id": "user1", "nome": "Ana Silva", "idade": 28},
             {"id": "user2", "nome": "João Santos", "idade": 35},
@@ -79,7 +89,16 @@ class SimpleDataLoader:
         print(f"✅ Dados mock carregados: {len(self.usuarios)} usuários, {len(self.musicas)} músicas, {len(self.playlists)} playlists")
 
 # Instância global do data loader
-data_loader = SimpleDataLoader()
+# Sempre que possível utilizamos os arquivos JSON gerados em ``data/``.
+# Caso o carregamento falhe (ex.: arquivos ausentes), recai-se para o loader
+# simplificado apenas para fins de demonstração.
+try:
+    data_loader = get_data_loader()
+    print("✅ Dados reais carregados do diretório 'data/'")
+except Exception as exc:  # pragma: no cover - falha somente em ambiente demo
+    print(f"⚠️  Erro ao carregar dados reais: {exc}")
+    print("🔄 Utilizando SimpleDataLoader como fallback")
+    data_loader = SimpleDataLoader()
 
 # Configuração do FastAPI
 @asynccontextmanager

--- a/soap_service.py
+++ b/soap_service.py
@@ -1,0 +1,63 @@
+"""SOAP Backend Stub
+====================
+
+Este arquivo contém a estrutura inicial de um serviço SOAP em Python. A
+implementação real pode utilizar bibliotecas como ``spyne`` ou ``zeep`` para
+expor o contrato WSDL e responder às operações SOAP. O objetivo deste stub é
+servir de guia de implementação para o projeto do Trabalho 6.
+"""
+
+# Dependências sugeridas:
+#   pip install spyne lxml
+#
+# O arquivo ``streaming.wsdl`` deve descrever as operações abaixo. As classes e
+# métodos aqui definidos mostram como integrar o ``StreamingDataLoader`` para
+# fornecer dados reais ao serviço.
+
+from typing import List
+
+# from spyne import Application, rpc, ServiceBase, Integer, Unicode, Array
+# from spyne.protocol.soap import Soap11
+# from spyne.server.wsgi import WsgiApplication
+
+from data_loader import get_data_loader
+
+# Instância única de dados usada por todas as operações
+data_loader = get_data_loader()
+
+
+# class StreamingService(ServiceBase):
+#     """Serviço SOAP com operações do streaming de músicas."""
+#
+#     @rpc(_returns=Array(Usuario))
+#     def listar_todos_usuarios(ctx):
+#         """Retorna todos os usuários cadastrados."""
+#         return data_loader.listar_todos_usuarios()
+#
+#     @rpc(Unicode, _returns=Array(Playlist))
+#     def listar_playlists_usuario(ctx, id_usuario):
+#         """Listar playlists de um usuário específico."""
+#         return data_loader.listar_playlists_usuario(id_usuario)
+#
+#     # Demais operações seguem a mesma ideia: utilizar ``data_loader`` para
+#     # recuperar músicas ou playlists e retornar os objetos SOAP correspondentes.
+
+
+def executar_servidor(porta: int = 8002) -> None:
+    """Executa o servidor SOAP.
+
+    Esta função deve criar a aplicação ``spyne.Application`` e disponibilizar o
+    WSDL em ``/soap?wsdl``. Ela é deixada como TODO para que os alunos completem
+    conforme a biblioteca escolhida.
+    """
+    # TODO: configurar Application e WsgiApplication
+    # app = Application([...])
+    # wsgi_app = WsgiApplication(app)
+    # from wsgiref.simple_server import make_server
+    # server = make_server("0.0.0.0", porta, wsgi_app)
+    # server.serve_forever()
+    raise NotImplementedError("Implementar servidor SOAP utilizando spyne")
+
+
+if __name__ == "__main__":
+    executar_servidor()


### PR DESCRIPTION
## Summary
- add Python stubs for SOAP and gRPC backends
- integrate `StreamingDataLoader` with REST and GraphQL services
- include fallback to existing mock loaders
- provide a simple JavaScript client stub

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6848157911f4832e91602c4cdcf21716