### PR TITLE
Handle DOMParser in Node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,4 +83,6 @@ dmypy.json
 .pytype/
 
 # Cython debug symbols
-cython_debug/ 
+cython_debug/
+
+node_modules/

--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ O projeto usa `uv` para gerenciamento de dependências:
 python main.py
 ```
 
+Para executar os clientes e testes em JavaScript é necessário instalar o pacote
+`xmldom` para que o `DOMParser` funcione no Node.js:
+
+```bash
+npm install xmldom
+```
+
 ### 2. Gerar Dados (Primeira Execução)
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "four-api-technologies-demo",
+  "version": "1.0.0",
+  "description": "Demo of REST, GraphQL, SOAP and gRPC",
+  "main": "test_services.js",
+  "dependencies": {
+    "xmldom": "^0.8.10"
+  }
+}

--- a/soap/client.js
+++ b/soap/client.js
@@ -2,6 +2,13 @@
  * SOAP Client for Streaming Service
  * Implements all required operations for the project
  */
+// Detect environment and use appropriate DOMParser implementation
+let DOMParser;
+if (typeof window === 'undefined') {
+    ({ DOMParser } = require('xmldom'));
+} else {
+    DOMParser = window.DOMParser;
+}
 class SOAPClient {
     constructor(endpoint = 'http://localhost:8004') {
         this.endpoint = endpoint;


### PR DESCRIPTION
## Summary
- support DOMParser in Node.js by using `xmldom`
- ignore `node_modules` and document Node dependency
- add package.json listing xmldom

## Testing
- `pytest -q` *(fails: ConnectionError: HTTPConnectionPool(host='localhost', port=8004) ...)*

------
https://chatgpt.com/codex/tasks/task_e_684952d604ec832e8516e1f7c37829a8