### PR TITLE
Fix SOAP operation names in test suite

### DIFF
--- a/test_services.js
+++ b/test_services.js
@@ -114,17 +114,17 @@ async function testSOAP() {
     console.log('\n📦 Testing SOAP API...');
     
     await runTest('List Users', async () => {
-        const result = await soapClient.executeOperation('ListarUsuarios');
+        const result = await soapClient.executeOperation('listar_usuarios');
         if (!result || !Array.isArray(result)) throw new Error('Invalid response format');
     }, 'soap');
 
     await runTest('List Songs', async () => {
-        const result = await soapClient.executeOperation('ListarMusicas');
+        const result = await soapClient.executeOperation('listar_musicas');
         if (!result || !Array.isArray(result)) throw new Error('Invalid response format');
     }, 'soap');
 
     await runTest('List Playlists', async () => {
-        const result = await soapClient.executeOperation('ListarPlaylists');
+        const result = await soapClient.executeOperation('listar_playlists');
         if (!result || !Array.isArray(result)) throw new Error('Invalid response format');
     }, 'soap');
 }


### PR DESCRIPTION
## Summary
- update SOAP tests to call lowercase operations
- run test suite

## Testing
- `pytest -q` *(fails: ConnectionError to localhost services)*

------
https://chatgpt.com/codex/tasks/task_e_684952d6c1c0832e8c834e21f2863fa1