### PR TITLE
Fix playlist sync in SOAP service

### DIFF
--- a/client_stub.js
+++ b/client_stub.js
@@ -9,7 +9,7 @@
 // URLs padrão dos serviços
 const REST_URL = 'http://localhost:8000';
 const GRAPHQL_URL = 'http://localhost:8001/graphql';
-const SOAP_URL = 'http://localhost:8002/soap';
+const SOAP_URL = 'http://localhost:8004/soap';
 const GRPC_URL = 'http://localhost:50051'; // gRPC usa porta separada
 
 // -------------------- REST --------------------


### PR DESCRIPTION
## Summary
- keep SOAP playlists in sync with `data_loader` by mapping live data
- fix `criar_playlist` to update the shared loader
- update JS stub to use the correct SOAP port

## Testing
- `pytest -q` *(fails: ConnectionError)*

------
https://chatgpt.com/codex/tasks/task_e_684956ba8e2c832ea2456da489b14544